### PR TITLE
Add help message

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,6 @@ int main(int argc, char *argv[])
     ctx = parse_cmd_line(argc, argv);
     if(ctx == NULL)
     {
-        output(ERROR, "Can't parse command line.\n");
         return (-1);
     }
 

--- a/src/runtime/nextgen.c
+++ b/src/runtime/nextgen.c
@@ -75,6 +75,7 @@ static struct option longopts[] = {{"in", required_argument, NULL, 'i'},
 
 static void display_help_banner(void)
 {
+    set_verbosity(TRUE);
     output(STD, "Nextgen is a Genetic File, Syscall, and Network Fuzzer.\n");
     output(STD,
            "To use the file fuzzer in smart mode run the command below.\n");
@@ -419,7 +420,7 @@ struct parser_ctx *parse_cmd_line(int32_t argc, char *argv[])
                 break;
 
             default:
-                output(ERROR, "Unknown option\n");
+                display_help_banner();
                 mem_free((void **)&ctx);
                 return (NULL);
         }
@@ -428,7 +429,7 @@ struct parser_ctx *parse_cmd_line(int32_t argc, char *argv[])
     /* Make sure a fuzzing mode was selected. */
     if(fFlag != TRUE && nFlag != TRUE && sFlag != TRUE)
     {
-        output(STD, "Specify a fuzzing mode\n");
+        display_help_banner();
         mem_free((void **)&ctx);
         return NULL;
     }


### PR DESCRIPTION
For issue #13 

Now running `nextgen`, outputs:

```
Nextgen is a Genetic File, Syscall, and Network Fuzzer.
To use the file fuzzer in smart mode run the command below.
sudo ./nextgen --file --in /path/to/in/directory --out /path/to/out/directory --exec /path/to/target/exec .
To use the syscall fuzzer in smart mode run.
sudo ./nextgen --syscall --out /path/to/out/directory
To use dumb mode just pass --dumb with any of the above commands.
```

As well as `nextgen -help` or `nextgen --help`. The --help and h will actually be interpreted as a valid option, to display the usage.

But other options such as -h, or -ajuda will print the usage as well. One minor improvement could be to leave the 'Unknown option' and also print the usage.

Cheers
Bruno
